### PR TITLE
Replace VSCO link with 500px in social links

### DIFF
--- a/src/app/components/social-link/social-link.ts
+++ b/src/app/components/social-link/social-link.ts
@@ -5,7 +5,7 @@ import {
   lucideGithub,
   lucideLinkedin,
   lucideMail,
-  lucideCamera,
+  lucideAperture,
   lucideTwitter,
 } from '@ng-icons/lucide';
 
@@ -19,7 +19,7 @@ import {
       lucideLinkedin,
       lucideTwitter,
       lucideCalendarClock,
-      lucideCamera,
+      lucideAperture,
     }),
   ],
   template: `

--- a/src/app/providers/links.provider.ts
+++ b/src/app/providers/links.provider.ts
@@ -43,7 +43,7 @@ export class LinksProvider {
     {
       name: '500px',
       description: 'Pictures I took and shared on 500px',
-      icon: 'lucideCamera',
+      icon: 'lucideAperture',
       route: 'https://500px.com/p/rolivencia',
       type: 'external',
     },

--- a/src/app/providers/links.provider.ts
+++ b/src/app/providers/links.provider.ts
@@ -41,10 +41,10 @@ export class LinksProvider {
       type: 'external',
     },
     {
-      name: 'VSCO',
-      description: 'Pictures I took and shared on VSCO',
+      name: '500px',
+      description: 'Pictures I took and shared on 500px',
       icon: 'lucideCamera',
-      route: 'https://vsco.co/rolivencia/gallery',
+      route: 'https://500px.com/p/rolivencia',
       type: 'external',
     },
   ]);


### PR DESCRIPTION
Switch the photography social link from VSCO to 500px, updating the name, description, and route, and use the lucide **aperture** icon (a lens iris) in place of the generic camera icon since it reads more clearly as photography.

- `src/app/providers/links.provider.ts` — name `VSCO` → `500px`, description updated, route `https://vsco.co/rolivencia/gallery` → `https://500px.com/p/rolivencia`, icon → `lucideAperture`
- `src/app/components/social-link/social-link.ts` — import/register `lucideAperture`, drop the now-unused `lucideCamera`

Rebased onto `develop` after the build fix (#66) merged, so the diff is now just the two files above.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Fser5vmXxQ5RTpnBMGzDQ